### PR TITLE
Updated peerDependencies for Grunt to be compatible with v1.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xmldoc": "^0.3.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Updated peerDependencies for Grunt to be compatible with v1.0.0+

see:  http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies
